### PR TITLE
making it compatible with Python 3

### DIFF
--- a/xgbmagic/__init__.py
+++ b/xgbmagic/__init__.py
@@ -1,1 +1,1 @@
-from xgbmagic import Xgb
+from .xgbmagic import Xgb


### PR DESCRIPTION
It looks like currently `xgbmagic` is not working with Python 3 - do you mind to change import to both py2 and py3 friendly way? 